### PR TITLE
fixed visual dark mode bug

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,7 +77,8 @@
             </intent-filter>
         </activity>
         <activity android:name="com.yalantis.ucrop.UCropActivity"
-            android:screenOrientation="fullSensor"
+            android:screenOrientation="sensorPortrait"
+            tools:ignore="LockedOrientationActivity"
             android:theme="@style/AppTheme.NoActionBar"/>
 
         <activity

--- a/app/src/main/res/layout/activity_photo_edit.xml
+++ b/app/src/main/res/layout/activity_photo_edit.xml
@@ -19,7 +19,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="@color/colorPrimary"
+        android:background="@color/colorPrimaryTab"
         app:popupTheme="@style/AppTheme.PopupOverlay"/>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Note: Please stop hardcoding your colors when creating layouts. It usually tends to fail miserably in dark mode. Use adaptive colors instead and test your result in both light and dark mode before merging.